### PR TITLE
fix: language selections appear in two places

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -192,8 +192,8 @@ class App extends Component {
     );
 
     return (
-      <Dropdown key="/rightDropDown" overlay={menu} className="rightDropDown">
-        <div className="ant-dropdown-link" style={{float: "right", cursor: "pointer"}}>
+      <Dropdown overlay={menu}>
+        <div className="top-right-button">
           &nbsp;
           &nbsp;
           {
@@ -217,28 +217,21 @@ class App extends Component {
       return null;
     } else if (this.state.account === null) {
       res.push(
-        <Menu.Item key="/signup" style={{float: "right", marginRight: "20px", border: "none"}}>
-          <a href={Setting.getSignupUrl()} className="signup-button">
-            {i18next.t("account:Sign Up")}
-          </a>
-        </Menu.Item>
-      );
-      res.push(
-        <Menu.Item key="/signin" style={{float: "right", border: "none"}}>
+        <div key="/signin">
           <a href={Setting.getSigninUrl()} className="signin-button">
             {i18next.t("account:Sign In")}
           </a>
-        </Menu.Item>
+        </div>
+      );
+      res.push(
+        <div key="/signup" style={{marginRight: "1rem"}}>
+          <a href={Setting.getSignupUrl()} className="signup-button">
+            {i18next.t("account:Sign Up")}
+          </a>
+        </div>
       );
     } else {
       res.push(this.renderRightDropdown());
-      return (
-        <div style={{float: "right", margin: "0px", padding: "0px"}}>
-          {
-            res
-          }
-        </div>
-      );
     }
 
     return res;
@@ -429,7 +422,7 @@ class App extends Component {
   renderContent() {
     return (
       <div>
-        <Header style={{padding: "0", marginBottom: "3px"}}>
+        <Header style={{padding: "0", marginBottom: "3px", display: "flex", flexWrap: "nowrap", backgroundColor: "white", borderBottom: "1px solid #f0f0f0"}}>
           {
             Setting.isMobile() ? null : (
               <Link to={"/"}>
@@ -441,16 +434,20 @@ class App extends Component {
             // theme="dark"
             mode={"horizontal"}
             selectedKeys={[`${this.state.selectedMenuKey}`]}
-            style={{lineHeight: "64px"}}
+            style={{lineHeight: "64px", width: "70%", marginRight: "auto", border: "none"}}
           >
             {
               this.renderMenu()
             }
+          </Menu>
+          <div
+            className="top-right-layout"
+          >
+            <SelectLanguageBox />
             {
               this.renderAccount()
             }
-            <SelectLanguageBox />
-          </Menu>
+          </div>
         </Header>
         <Switch>
           <Route exact path="/callback" component={AuthCallback} />

--- a/web/src/App.less
+++ b/web/src/App.less
@@ -43,7 +43,7 @@
   overflow-y: hidden !important
 }
 
-.language_box {
+.language-box {
   background: url("https://cdn.casbin.org/img/muti_language.svg");
   background-size: 25px, 25px;
   background-position: center;
@@ -52,15 +52,47 @@
   height: 65px;
   float: right;
   cursor: pointer;
+  &:hover {
+    background-color: #f5f5f5;
+  }
 }
 
-.language_box:hover {
-  background-color: #f5f5f5;
+.top-right-layout {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 1rem;
+  .top-right-button {
+    flex-shrink: 0;
+    cursor: pointer;
+    &:hover {
+      background-color: #f5f5f5;
+    }
+  }
 }
 
+.signin-button {
+  color: black !important;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  border-radius: 1rem;
+  transition: all 0.3s ease-in-out;
+  &:hover {
+    background-color: rgba(32, 33, 36, 0.1);
+  }
+}
 
-.rightDropDown:hover {
-  background-color: #f5f5f5;
+.signup-button {
+  color: white !important;
+  background-color: #7f5de3;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  border-radius: 1rem;
+  transition: all 0.3s ease-in-out;
+  &:hover {
+    box-shadow: 0rem 0rem 0.3rem #7f5de3;
+  }
 }
 
 .signin-button {

--- a/web/src/SelectLanguageBox.js
+++ b/web/src/SelectLanguageBox.js
@@ -14,13 +14,18 @@
 
 import React from "react";
 import * as Setting from "./Setting";
-import {Menu} from "antd";
+import {Dropdown, Menu} from "antd";
 import {createFromIconfontCN} from "@ant-design/icons";
 import "./App.less";
 
 const IconFont = createFromIconfontCN({
   scriptUrl: "//at.alicdn.com/t/font_2680620_ffij16fkwdg.js",
 });
+
+const LanguageItems = [
+  {lang: "en", label: "English", icon: "icon-en"},
+  {lang: "zh", label: "中文", icon: "icon-zh"},
+];
 
 class SelectLanguageBox extends React.Component {
   constructor(props) {
@@ -31,32 +36,9 @@ class SelectLanguageBox extends React.Component {
   }
 
   render() {
-    return (
-      <React.Fragment>
-        <Menu.Item key="en" className="rightDropDown" style={{float: "right", cursor: "pointer", marginRight: "20px"}} icon={<React.Fragment>&nbsp;&nbsp;&nbsp;&nbsp;<IconFont type="icon-en" /></React.Fragment>}
-          onClick={() => {
-            Setting.changeLanguage("en");
-          }}
-          onItemHover={() => {}}
-        >
-          &nbsp;
-          English
-          &nbsp;
-          &nbsp;
-        </Menu.Item>
-        <Menu.Item key="zh" className="rightDropDown" style={{float: "right", cursor: "pointer"}} icon={<React.Fragment>&nbsp;&nbsp;&nbsp;&nbsp;<IconFont type="icon-zh" /></React.Fragment>}
-          onClick={() => {
-            Setting.changeLanguage("zh");
-          }}
-          onItemHover={() => {}}
-        >
-          &nbsp;
-          中文
-          &nbsp;
-          &nbsp;
-        </Menu.Item>
-      </React.Fragment>
-    );
+    return <Dropdown overlay={<Menu>{LanguageItems.map(({lang, label, icon}) => <Menu.Item key={lang} onClick={() => Setting.changeLanguage(lang)}><IconFont type={icon} />{label}</Menu.Item>)}</Menu>}>
+      <div className="language-box"></div>
+    </Dropdown>;
   }
 }
 


### PR DESCRIPTION
### Description
1. Use a drop-down menu instead of an inline menu for better looking and scalability.
2. Refact part of `App.less` to make it more concise.
3. Using custom `div` element instead of Ant Design `Menu` for better stability in this case. (The default behavior of the `Menu` component doesn't look good in this case, and the workaround could be unstable).

### Preview
You can preview this PR right here:

http://47.92.5.125:3000/

user: admin
passwd: 123

### Relating issue

Fix: https://github.com/casbin/confita/issues/20