### PR TITLE
fix: Add frontend linter to CI checker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  frontend-linter:
+    name: Frontend Linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+        # cache
+      - uses: c-hive/gha-yarn-cache@v2
+        with:
+          directory: ./web
+      - run: yarn install && yarn run lint
+        working-directory: ./web

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,8 @@
     "test": "craco test",
     "eject": "craco eject",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "fix": "eslint --fix src/*.js src/backend/*.js"
+    "fix": "eslint --fix src/*.js src/backend/*.js",
+    "lint": "eslint src/*.js src/backend/*.js"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Fix: https://github.com/casbin/confita/issues/16

# Description
1. Add the `lint` script in `package.json`.
2. Call the `lint` script in `CI`.