### PR TITLE
fix: conference page not display default content

### DIFF
--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -31,9 +31,12 @@ class Conference extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      selectedKey: (/\/(.*)/g.exec(this.props.history.location.pathname) ?? [])[1],
-    });
+    const match = /\/(.+)/.exec(this.props.history.location.pathname);
+    if (match !== null) {
+      this.setState({
+        selectedKey: match[1],
+      });
+    }
   }
 
   handleClick = info => {


### PR DESCRIPTION
# Bug Description
When you enter the conference page, selectedKey will be set to "", which will cause conference.defaultItem to stop working.

# Fix
Only set selectedKey when the path is exactly the child page of the conference page.

# Preview 
![preview](47.92.5.125:3000)