### PR TITLE
Fix: wrong router config

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -507,7 +507,6 @@ class App extends Component {
         <Switch>
           <Route exact path="/callback" component={AuthCallback} />
           <Route exact path="/" render={(props) => <HomePage account={this.state.account} {...props} />} />
-          <Route exact path="/:menu" render={(props) => <HomePage account={this.state.account} {...props} />} />
           <Route exact path="/signin" render={(props) => this.renderHomeIfSignedIn(<SigninPage {...props} />)} />
           <Route exact path="/payments" render={(props) => this.renderSigninIfNotSignedIn(<PaymentPage account={this.state.account} {...props} />)} />
           <Route exact path="/contact" render={(props) => this.renderSigninIfNotSignedIn(<ContactPage account={this.state.account} {...props} />)} />
@@ -524,6 +523,7 @@ class App extends Component {
           <Route exact path="/rooms/:userName/:roomName/view" render={(props) => <RoomPage account={this.state.account} {...props} />} />
           <Route exact path="/rooms/:userName/:roomName/:slotName/view" render={(props) => <RoomPage account={this.state.account} {...props} />} />
           <Route exact path="/public-rooms" render={(props) => <RoomListPage key={"public-rooms"} account={this.state.account} isPublic={true} {...props} />} />
+          <Route exact path="/:menu" render={(props) => <HomePage account={this.state.account} {...props} />} />
         </Switch>
       </div>
     );

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -507,6 +507,7 @@ class App extends Component {
         <Switch>
           <Route exact path="/callback" component={AuthCallback} />
           <Route exact path="/" render={(props) => <HomePage account={this.state.account} {...props} />} />
+          <Route exact path="/:menu" render={(props) => <HomePage account={this.state.account} {...props} />} />
           <Route exact path="/signin" render={(props) => this.renderHomeIfSignedIn(<SigninPage {...props} />)} />
           <Route exact path="/payments" render={(props) => this.renderSigninIfNotSignedIn(<PaymentPage account={this.state.account} {...props} />)} />
           <Route exact path="/contact" render={(props) => this.renderSigninIfNotSignedIn(<ContactPage account={this.state.account} {...props} />)} />

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -31,9 +31,12 @@ class Conference extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      selectedKey: (/\/(.*)/g.exec(this.props.history.location.pathname) ?? [])[1],
-    });
+    const match = /\/(.+)/.exec(this.props.history.location.pathname);
+    if (match !== null) {
+      this.setState({
+        selectedKey: match[1],
+      });
+    }
   }
 
   handleClick = info => {

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from "react";
+import {withRouter} from "react-router-dom";
 import {Alert, Button, Col, Empty, Menu, Popover, Row, Space, Steps} from "antd";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -29,8 +30,15 @@ class Conference extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.setState({
+      selectedKey: (/\/(.*)/g.exec(this.props.history.location.pathname) ?? [])[1],
+    });
+  }
+
   handleClick = info => {
     const selectedKey = info.key;
+    this.props.history.push(info.key);
     this.setState({
       selectedKey: selectedKey,
     });
@@ -294,4 +302,4 @@ class Conference extends React.Component {
   }
 }
 
-export default Conference;
+export default withRouter(Conference);


### PR DESCRIPTION
# Bug Description

Users are unable to navigate to any pages other than the home page.

# Reason

In the route configuration in the `App.js` component, the `/:menu` route will match any URL that has a non-empty path after the `/` character. This is causing the `HomePage` component to be rendered for all URLs, regardless of whether the path is actually a valid value for the `menu` parameter or the path of another page.

# Solution

To fix this issue, we can update the router match priority configuration in `App.js`.

# Preview

http://47.92.5.125:3000/test