### PR TITLE
Feat: Minor Improvement of Conference Component

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -507,7 +507,6 @@ class App extends Component {
         <Switch>
           <Route exact path="/callback" component={AuthCallback} />
           <Route exact path="/" render={(props) => <HomePage account={this.state.account} {...props} />} />
-          <Route exact path="/:menu" render={(props) => <HomePage account={this.state.account} {...props} />} />
           <Route exact path="/signin" render={(props) => this.renderHomeIfSignedIn(<SigninPage {...props} />)} />
           <Route exact path="/payments" render={(props) => this.renderSigninIfNotSignedIn(<PaymentPage account={this.state.account} {...props} />)} />
           <Route exact path="/contact" render={(props) => this.renderSigninIfNotSignedIn(<ContactPage account={this.state.account} {...props} />)} />
@@ -524,6 +523,7 @@ class App extends Component {
           <Route exact path="/rooms/:userName/:roomName/view" render={(props) => <RoomPage account={this.state.account} {...props} />} />
           <Route exact path="/rooms/:userName/:roomName/:slotName/view" render={(props) => <RoomPage account={this.state.account} {...props} />} />
           <Route exact path="/public-rooms" render={(props) => <RoomListPage key={"public-rooms"} account={this.state.account} isPublic={true} {...props} />} />
+          <Route exact path="/:menu" render={(props) => <HomePage account={this.state.account} {...props} />} />
         </Switch>
       </div>
     );

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -507,6 +507,7 @@ class App extends Component {
         <Switch>
           <Route exact path="/callback" component={AuthCallback} />
           <Route exact path="/" render={(props) => <HomePage account={this.state.account} {...props} />} />
+          <Route exact path="/:menu" render={(props) => <HomePage account={this.state.account} {...props} />} />
           <Route exact path="/signin" render={(props) => this.renderHomeIfSignedIn(<SigninPage {...props} />)} />
           <Route exact path="/payments" render={(props) => this.renderSigninIfNotSignedIn(<PaymentPage account={this.state.account} {...props} />)} />
           <Route exact path="/contact" render={(props) => this.renderSigninIfNotSignedIn(<ContactPage account={this.state.account} {...props} />)} />

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -26,12 +26,18 @@ class Conference extends React.Component {
     super(props);
     this.state = {
       classes: props,
-      selectedKey: this.props.conference.defaultItem,
+      enableMenuPath: props.enableMenuPath || false,
+      path: props.path || "/",
+      selectedKey: props.conference.defaultItem,
     };
   }
 
   componentDidMount() {
-    const match = /\/(.+)/.exec(this.props.history.location.pathname);
+    if (!this.props.enableMenuPath) {
+      return;
+    }
+
+    const match = new RegExp(`${this.props.path}(.+)`).exec(this.props.history.location.pathname);
     if (match !== null) {
       this.setState({
         selectedKey: match[1],
@@ -41,7 +47,9 @@ class Conference extends React.Component {
 
   handleClick = info => {
     const selectedKey = info.key;
-    this.props.history.push(info.key);
+    if (this.props.enableMenuPath) {
+      this.props.history.push(`${this.props.path}${info.key}`);
+    }
     this.setState({
       selectedKey: selectedKey,
     });

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -31,9 +31,12 @@ class Conference extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      selectedKey: (/\/(.*)/g.exec(this.props.history.location.pathname) ?? [])[1],
-    });
+    const match = /\/(.+)/.exec(this.props.history.location.pathname);
+    if (match !== null) {
+      this.setState({
+        selectedKey: match[1],
+      });
+    }
   }
 
   handleClick = info => {

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from "react";
+import {withRouter} from "react-router-dom";
 import {Alert, Button, Col, Empty, Menu, Popover, Row, Space, Steps} from "antd";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -29,8 +30,15 @@ class Conference extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.setState({
+      selectedKey: (/\/(.*)/g.exec(this.props.history.location.pathname) ?? [])[1],
+    });
+  }
+
   handleClick = info => {
     const selectedKey = info.key;
+    this.props.history.push(info.key);
     this.setState({
       selectedKey: selectedKey,
     });
@@ -294,4 +302,4 @@ class Conference extends React.Component {
   }
 }
 
-export default Conference;
+export default withRouter(Conference);

--- a/web/src/HomePage.js
+++ b/web/src/HomePage.js
@@ -79,7 +79,13 @@ class HomePage extends React.Component {
             this.renderCarousel(this.state.conference)
           }
         </div>
-        <Conference conference={this.state.conference} language={Setting.getLanguage()} history={this.props.history} />
+        <Conference
+          conference={this.state.conference}
+          language={Setting.getLanguage()}
+          history={this.props.history}
+          path="/"
+          enableMenuPath={true}
+        />
       </div>
     );
   }


### PR DESCRIPTION
# Description

Add the `enableMenuPath` prop, which is used to determine whether the component should enable the ability to update the URL path in the browser's address bar based on the user's selection in the menu. If this prop is true, the component will listen for changes to the menu selection and update the URL path accordingly. Otherwise, **the component will not modify the URL path.**

This prop can improve the reusability of the Conference component by preventing menu items from unexpectedly modifying the URL path.