### PR TITLE
feat: let the conference menu item has its own URL path

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -97,7 +97,7 @@ class App extends Component {
     } else if (uri.includes("/public-rooms")) {
       this.setState({selectedMenuKey: "/public-rooms"});
     } else {
-      this.setState({selectedMenuKey: "null"});
+      this.setState({selectedMenuKey: "/"});
     }
   }
 
@@ -523,6 +523,7 @@ class App extends Component {
           <Route exact path="/rooms/:userName/:roomName/view" render={(props) => <RoomPage account={this.state.account} {...props} />} />
           <Route exact path="/rooms/:userName/:roomName/:slotName/view" render={(props) => <RoomPage account={this.state.account} {...props} />} />
           <Route exact path="/public-rooms" render={(props) => <RoomListPage key={"public-rooms"} account={this.state.account} isPublic={true} {...props} />} />
+          <Route exact path="/:menu+" render={(props) => <HomePage account={this.state.account} {...props} />} />
         </Switch>
       </div>
     );

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from "react";
+import {Link, withRouter} from "react-router-dom";
 import {Alert, Button, Col, Empty, Menu, Popover, Row, Space, Steps} from "antd";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -21,20 +22,53 @@ const {SubMenu} = Menu;
 const {Step} = Steps;
 
 class Conference extends React.Component {
+  static defaultProps = {
+    path: "/",
+    enableMenuPath: false,
+  };
+
   constructor(props) {
     super(props);
     this.state = {
       classes: props,
-      selectedKey: this.props.conference.defaultItem,
+      selectedKey: props.conference.defaultItem,
     };
   }
 
-  handleClick = info => {
-    const selectedKey = info.key;
-    this.setState({
-      selectedKey: selectedKey,
-    });
-  };
+  componentDidMount() {
+    this.updateSelectedKey();
+  }
+
+  componentDidUpdate() {
+    this.updateSelectedKey();
+  }
+
+  shouldComponentUpdate(nextProp, nextState) {
+    if (nextState.selectedKey !== this.state.selectedKey || nextProp.conference !== this.props.conference) {
+
+      const selectedTreeItem = this.getSelectedTreeItem(nextState.selectedKey, nextProp.conference.treeItems);
+
+      if (typeof this.props.onMatchTreeItem === "function") {
+        this.props.onMatchTreeItem(!!selectedTreeItem);
+      }
+
+      return true;
+    }
+    return false;
+  }
+
+  updateSelectedKey() {
+    if (!this.props.enableMenuPath) {
+      return;
+    }
+
+    const match = new RegExp(`${this.props.path}([^/]+)$`).exec(this.props.history.location.pathname);
+    if (match !== null) {
+      this.setState({
+        selectedKey: match[1],
+      });
+    }
+  }
 
   renderMenu(treeItems) {
     let mode;
@@ -66,8 +100,10 @@ class Conference extends React.Component {
 
             if (treeItem.children.length === 0) {
               return (
-                <Menu.Item key={treeItem.title}>
-                  {this.props.language !== "en" ? treeItem.title : treeItem.titleEn}
+                <Menu.Item key={treeItem.title} onClick={this.updateSelectedKey.bind(this)}>
+                  <Link to={`${this.props.path}${treeItem.title}`}>
+                    {this.props.language !== "en" ? treeItem.title : treeItem.titleEn}
+                  </Link>
                 </Menu.Item>
               );
             } else {
@@ -76,8 +112,10 @@ class Conference extends React.Component {
                   {
                     treeItem.children.map((treeItem2, i) => {
                       return (
-                        <Menu.Item key={treeItem2.title}>
-                          {this.props.language !== "en" ? treeItem2.title : treeItem2.titleEn}
+                        <Menu.Item key={treeItem2.title} onClick={this.updateSelectedKey.bind(this)}>
+                          <Link to={`${this.props.path}${treeItem.title}/${treeItem2.title}`}>
+                            {this.props.language !== "en" ? treeItem2.title : treeItem2.titleEn}
+                          </Link>
                         </Menu.Item>
                       );
                     })
@@ -122,16 +160,16 @@ class Conference extends React.Component {
     );
   }
 
-  getSelectedTreeItem(treeItems) {
-    if (this.state.selectedKey === null) {
+  getSelectedTreeItem(selectedKey, treeItems) {
+    if (selectedKey === null) {
       return null;
     }
 
     const res = treeItems.map(treeItem => {
-      if (treeItem.title === this.state.selectedKey) {
+      if (treeItem.title === selectedKey) {
         return treeItem;
       } else {
-        return this.getSelectedTreeItem(treeItem.children);
+        return this.getSelectedTreeItem(selectedKey, treeItem.children);
       }
     }).filter(treeItem => treeItem !== null);
 
@@ -235,6 +273,11 @@ class Conference extends React.Component {
 
   render() {
     const conference = this.props.conference;
+    const selectedTreeItem = this.getSelectedTreeItem(this.state.selectedKey, conference.treeItems);
+
+    if (!selectedTreeItem) {
+      return null;
+    }
 
     if (!Setting.isMobile()) {
       return (
@@ -256,7 +299,7 @@ class Conference extends React.Component {
             </Col>
             <Col span={19} >
               {
-                this.renderPage(this.getSelectedTreeItem(conference.treeItems))
+                this.renderPage(selectedTreeItem)
               }
             </Col>
           </Row>
@@ -283,7 +326,7 @@ class Conference extends React.Component {
             <Col span={1} />
             <Col span={22} >
               {
-                this.renderPage(this.getSelectedTreeItem(conference.treeItems))
+                this.renderPage(selectedTreeItem)
               }
             </Col>
             <Col span={1} />
@@ -294,4 +337,4 @@ class Conference extends React.Component {
   }
 }
 
-export default Conference;
+export default withRouter(Conference);

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -29,9 +29,12 @@ class Conference extends React.Component {
 
   constructor(props) {
     super(props);
+
+    const selectedKey = this.getSelectedKey(props);
+
     this.state = {
       classes: props,
-      selectedKey: props.conference.defaultItem,
+      selectedKey: selectedKey || props.conference.defaultItem,
     };
   }
 
@@ -57,17 +60,26 @@ class Conference extends React.Component {
     return false;
   }
 
-  updateSelectedKey() {
-    if (!this.props.enableMenuPath) {
-      return;
+  getSelectedKey(props) {
+    if (!props.enableMenuPath) {
+      return null;
     }
 
-    const match = new RegExp(`${this.props.path}([^/]+)$`).exec(this.props.history.location.pathname);
-    if (match !== null) {
-      this.setState({
-        selectedKey: match[1],
-      });
+    const match = new RegExp(`${props.path}([^/]+)$`).exec(props.history.location.pathname);
+
+    if (match === null) {
+      return null;
     }
+
+    return match[1];
+  }
+
+  updateSelectedKey() {
+    const selectedKey = this.getSelectedKey(this.props);
+    if (selectedKey === null) {
+      return;
+    }
+    this.setState({selectedKey});
   }
 
   renderMenu(treeItems) {

--- a/web/src/HomePage.js
+++ b/web/src/HomePage.js
@@ -25,6 +25,7 @@ class HomePage extends React.Component {
     this.state = {
       classes: props,
       conference: null,
+      isMatchConferenceTreeItem: true,
     };
   }
 
@@ -67,6 +68,12 @@ class HomePage extends React.Component {
     );
   }
 
+  handleMatchConferenceTreeItem(isMatched) {
+    this.setState({
+      isMatchConferenceTreeItem: isMatched,
+    });
+  }
+
   renderHome() {
     if (this.state.conference === null) {
       return null;
@@ -79,12 +86,23 @@ class HomePage extends React.Component {
             this.renderCarousel(this.state.conference)
           }
         </div>
-        <Conference conference={this.state.conference} language={Setting.getLanguage()} history={this.props.history} />
+        <Conference
+          conference={this.state.conference}
+          language={Setting.getLanguage()}
+          history={this.props.history}
+          path="/"
+          enableMenuPath={true}
+          onMatchTreeItem={this.handleMatchConferenceTreeItem.bind(this)}
+        />
       </div>
     );
   }
 
   render() {
+    if (!this.state.isMatchConferenceTreeItem) {
+      return null;
+    }
+
     return (
       <div>
         <Row style={{width: "100%"}}>


### PR DESCRIPTION
Fix: https://github.com/casbin/confita/issues/29

# Description
1. When clicking a menu item, navigate to the associated path.
2. Including a `Link` element within the menu item for improved accessibility. 
3. If the path does not match any other pages, use a catch-all route to handle it, and route to the home page.
# Preview
http://47.92.5.125:3000/test
http://47.92.5.125:3000/test/test21
