### PR TITLE
fix: i18n support in the Conference component.

### DIFF
--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -112,20 +112,20 @@ class Conference extends React.Component {
 
             if (treeItem.children.length === 0) {
               return (
-                <Menu.Item key={treeItem.title} onClick={this.updateSelectedKey.bind(this)}>
-                  <Link to={`${this.props.path}${treeItem.title}`}>
+                <Menu.Item key={treeItem.titleEn} onClick={this.updateSelectedKey.bind(this)}>
+                  <Link to={`${this.props.path}${treeItem.titleEn}`}>
                     {this.props.language !== "en" ? treeItem.title : treeItem.titleEn}
                   </Link>
                 </Menu.Item>
               );
             } else {
               return (
-                <SubMenu key={treeItem.title} title={this.props.language !== "en" ? treeItem.title : treeItem.titleEn}>
+                <SubMenu key={treeItem.titleEn} title={this.props.language !== "en" ? treeItem.title : treeItem.titleEn}>
                   {
                     treeItem.children.map((treeItem2, i) => {
                       return (
-                        <Menu.Item key={treeItem2.title} onClick={this.updateSelectedKey.bind(this)}>
-                          <Link to={`${this.props.path}${treeItem.title}/${treeItem2.title}`}>
+                        <Menu.Item key={treeItem2.titleEn} onClick={this.updateSelectedKey.bind(this)}>
+                          <Link to={`${this.props.path}${treeItem.titleEn}/${treeItem2.titleEn}`}>
                             {this.props.language !== "en" ? treeItem2.title : treeItem2.titleEn}
                           </Link>
                         </Menu.Item>
@@ -178,7 +178,7 @@ class Conference extends React.Component {
     }
 
     const res = treeItems.map(treeItem => {
-      if (treeItem.title === selectedKey) {
+      if (treeItem.titleEn === selectedKey) {
         return treeItem;
       } else {
         return this.getSelectedTreeItem(selectedKey, treeItem.children);

--- a/web/src/Conference.js
+++ b/web/src/Conference.js
@@ -47,6 +47,9 @@ class Conference extends React.Component {
   }
 
   shouldComponentUpdate(nextProp, nextState) {
+    if (nextProp.language !== this.props.language) {
+      return true;
+    }
     if (nextState.selectedKey !== this.state.selectedKey || nextProp.conference !== this.props.conference) {
 
       const selectedTreeItem = this.getSelectedTreeItem(nextState.selectedKey, nextProp.conference.treeItems);

--- a/web/src/HomePage.js
+++ b/web/src/HomePage.js
@@ -26,11 +26,17 @@ class HomePage extends React.Component {
       classes: props,
       conference: null,
       isMatchConferenceTreeItem: true,
+      language: Setting.getLanguage(),
     };
   }
 
   UNSAFE_componentWillMount() {
     this.getConference();
+    Setting.onLanguageChange(language => {
+      this.setState({
+        language,
+      });
+    });
   }
 
   getConference() {
@@ -88,7 +94,7 @@ class HomePage extends React.Component {
         </div>
         <Conference
           conference={this.state.conference}
-          language={Setting.getLanguage()}
+          language={this.state.language}
           history={this.props.history}
           path="/"
           enableMenuPath={true}

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -266,6 +266,15 @@ export function getLanguage() {
   return i18next.language;
 }
 
+export function onLanguageChange(callBack) {
+  if (typeof callBack !== "function") {
+    return null;
+  }
+
+  i18next.on("languageChanged", callBack);
+  return () => i18next.off("languageChanged", callBack);
+}
+
 export function setLanguage(language) {
   localStorage.setItem("language", language);
   changeMomentLanguage(language);


### PR DESCRIPTION
# Description
1. Change the language of menu title in the `Conference` component while the `languageChanged` event of `i18next` triggered.
2. Using the English menu title as the menu key in the `Conference` component.
# Preview
http://47.92.5.125:3000/test